### PR TITLE
fix(site_meta): dont search when href is None

### DIFF
--- a/feedsearch/site_meta.py
+++ b/feedsearch/site_meta.py
@@ -247,6 +247,8 @@ class SiteMeta:
         link_hrefs = list(get_link_href(links))
         for site_name, pattern in link_tests.items():
             for href in link_hrefs:
+                if not href:
+                    continue
                 if re.search(pattern, href, flags=re.I):
                     results.add(site_name)
 


### PR DESCRIPTION
# Description
Hi thanks for the wonderful library. I found a small issue where `href` may sometimes be `None` and this worked for me.
Would this be an appropriate fix to add in?

Here is the error:
Running:
```py3
import feedsearch
feedsearch.search('https://kbtx.com')
```

results in:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-2bcc07db8860> in <module>
      1 import feedsearch
----> 2 feedsearch.search('https://kbtx.com' class="ansi-blue-fg">)

XXXXXXXXXXXXXXXXXX/lib/python3.8/site-packages/feedsearch/feedsearch.py in search(url, info, check_all, cms, discovery_only, favicon_data_uri, as_urls, timeout, user_agent, max_redirects, parser, exceptions, verify)
     73         set_bs4_parser(parser)
     74         # Find feeds
---> 75         feeds = _find_feeds(
     76             url,
     77             feed_info=info,

XXXXXXXXXXXXXXXXXX/lib/python3.8/site-packages/feedsearch/lib.py in wrap(*args, **kwargs)
    238         start = time.perf_counter()
    239 
--> 240         result = func(*args, **kwargs)
    241 
    242         dur = int((time.perf_counter() - start) * 1000)

XXXXXXXXXXXXXXXXXX/lib/python3.8/site-packages/feedsearch/feedsearch.py in _find_feeds(url, feed_info, check_all, cms, discovery_only, favicon_data_uri)
    195             finder.get_site_info(coerced_url)
    196         logger.debug("Looking for CMS feeds.")
--> 197         cms_urls = finder.site_meta.cms_feed_urls()
    198         found_cms = finder.check_urls(cms_urls)
    199         logger.info("Found %s CMS feeds.", len(found_cms))

XXXXXXXXXXXXXXXXXX/lib/python3.8/site-packages/feedsearch/site_meta.py in cms_feed_urls(self)
    196 
    197         links = self.soup.find_all(name="link")
--> 198         site_names.update(self.check_links(links))
    199 
    200         for name in site_names:

XXXXXXXXXXXXXXXXXX/lib/python3.8/site-packages/feedsearch/site_meta.py in check_links(links)
    248         for site_name, pattern in link_tests.items():
    249             for href in link_hrefs:
--> 250                 if re.search(pattern, href, flags=re.I):
    251                     results.add(site_name)
    252 

~/.pyenv/versions/3.8.7/lib/python3.8/re.py in search(pattern, string, flags)
    199     """Scan through string looking for a match to the pattern, returning
    200     a Match object, or None if no match was found."""
--> 201     return _compile(pattern, flags).search(string)
    202 
    203 def sub(pattern, repl, string, count=0, flags=0):

TypeError: expected string or bytes-like object

```